### PR TITLE
ui: soft delete activity for checkin creation

### DIFF
--- a/functions/src/api-schema.ts
+++ b/functions/src/api-schema.ts
@@ -114,6 +114,7 @@ export type ActivityAction = z.infer<typeof ActivityAction>
 export const ActivitySchema = BaseSchema.and(ActivityAction).and(
   z.object({
     viewerIds: z.array(z.string()),
+    deleted: z.boolean().default(false),
   }),
 )
 

--- a/functions/src/migrations/backfillActivitiesDeleted.ts
+++ b/functions/src/migrations/backfillActivitiesDeleted.ts
@@ -1,0 +1,61 @@
+// ran with:
+// ./node_modules/.bin/esbuild src/migrations/backfillCheckins.ts --bundle --minify --sourcemap --platform=node --target=node16 --outfile=build/activityBackfill.js && node build/activityBackfill.js
+
+import * as admin from "firebase-admin"
+
+const config = {
+  credential: admin.credential.cert(
+    "foodieyak-ef36d-firebase-adminsdk-mqdva-1a95a419bf.json",
+  ),
+}
+
+admin.initializeApp(config)
+
+const db = admin.firestore()
+
+async function backfillPlacesAndCheckinsAndMenuitems() {
+  const activities = await db
+    .collection("activities")
+    .where("document", "==", "checkin")
+    .where("type", "==", "create")
+    .get()
+
+  console.log("update activities...")
+  await Promise.all(
+    activities.docs.map(async (activity) => {
+      await activity.ref.update({
+        deleted: false,
+      })
+    }),
+  )
+
+  console.log("update checkins...")
+  await Promise.all(
+    activities.docs.map(async (activity) => {
+      await activity.ref.update({
+        deleted: false,
+      })
+
+      const checkinId = activity.data().checkinId
+      const placeId = activity.data().placeId
+      if (
+        (await db.doc(`/places/${placeId}/checkins/${checkinId}`).get()).exists
+      ) {
+        await db
+          .doc(`/places/${placeId}/checkins/${checkinId}`)
+          .update({ activityId: activity.id })
+      } else {
+        console.log("checkin deleted", activity.id, checkinId)
+        await activity.ref.update({
+          deleted: true,
+        })
+      }
+    }),
+  )
+}
+
+async function main() {
+  await backfillPlacesAndCheckinsAndMenuitems()
+}
+
+main().catch((e) => console.error(e))

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -97,6 +97,7 @@ export const checkin = {
       comment,
       ratings: reviews,
       ratingsMenuItemIds: reviews.map((x) => x.menuItemId),
+      deleted: false,
     }
     const res = await addDoc(
       collection(db, "places", placeId, "checkins"),
@@ -119,7 +120,10 @@ export const checkin = {
     comment: string
     reviews: { menuItemId: string; rating: -1 | 1; comment: string }[]
   }) {
-    const checkin: Omit<PlaceCheckIn, "id" | "createdById" | "createdAt"> = {
+    const checkin: Omit<
+      PlaceCheckIn,
+      "id" | "createdById" | "createdAt" | "deleted"
+    > = {
       checkedInAt: date != null ? Timestamp.fromDate(date) : null,
       lastModifiedAt: Timestamp.now(),
       lastModifiedById: userId,

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -97,7 +97,6 @@ export const checkin = {
       comment,
       ratings: reviews,
       ratingsMenuItemIds: reviews.map((x) => x.menuItemId),
-      deleted: false,
     }
     const res = await addDoc(
       collection(db, "places", placeId, "checkins"),

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -231,6 +231,7 @@ export function useActivities({
       return query(
         collection(db, "activities"),
         where("viewerIds", "array-contains", userId),
+        where("deleted", "==", false),
         where("document", "==", "checkin"),
         where("type", "==", "create"),
         orderBy("createdAt", "desc"),


### PR DESCRIPTION
we don't want to show created checkin events if they are later deleted in the activity list view (when filtered to only checkins aka the default)

have to do a bunch of housekeeping to make it happen + a backfill