### PR TITLE
ui: skip writing activity for undated aka backfill checkins

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -478,13 +478,20 @@ export const checkinOnChange = functions.firestore
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const createdById: string = unwrap(change.after.data()?.createdById)
-      await createActivity({
-        actorId: createdById,
-        document: "checkin",
-        checkinId,
-        placeId,
-        type: "create",
-      })
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const checkedInAt: string | null | undefined =
+        change.after.data()?.checkedInAt
+
+      // skip checkins that are created without a date aka manual backfill ones
+      if (checkedInAt != null) {
+        await createActivity({
+          actorId: createdById,
+          document: "checkin",
+          checkinId,
+          placeId,
+          type: "create",
+        })
+      }
     }
     if (!change.after.exists) {
       // delete

--- a/functions/src/migrations/deleteBackfillActivities.ts
+++ b/functions/src/migrations/deleteBackfillActivities.ts
@@ -1,0 +1,54 @@
+/* eslint-disable no-console */
+// ran with:
+// ./node_modules/.bin/esbuild src/migrations/backfillCheckins.ts --bundle --minify --sourcemap --platform=node --target=node16 --outfile=build/activityBackfill.js && node build/activityBackfill.js
+
+import * as admin from "firebase-admin"
+
+const config = {
+  credential: admin.credential.cert(
+    "foodieyak-ef36d-firebase-adminsdk-mqdva-7ce20a8f6a.json",
+  ),
+}
+
+admin.initializeApp(config)
+
+const db = admin.firestore()
+
+async function migrate() {
+  const activities = await db
+    .collection("activities")
+    .where("document", "==", "checkin")
+    .where("type", "==", "create")
+    .get()
+
+  // eslint-disable-next-line no-console
+  console.log("update activities...")
+  await Promise.all(
+    activities.docs.map(async (activity) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const checkinId = activity.data().checkinId
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const placeId = activity.data().placeId
+      const checkin = await db
+        .doc(`/places/${placeId}/checkins/${checkinId}`)
+        .get()
+      if (checkin.exists) {
+        if (checkin.data()?.checkedInAt == null) {
+          console.log("checkin missing createdAt, deleting...")
+          await activity.ref.delete()
+        } else {
+          console.log("checkin has createdAt, skipping")
+        }
+      }
+    }),
+  )
+}
+
+async function main() {
+  await migrate()
+}
+
+main().catch((e) => {
+  // eslint-disable-next-line no-console
+  console.error(e)
+})


### PR DESCRIPTION
if you want to add a checkin but you don't know the date, you can leave it off

basically to allow backfills but I don't think we should record activity for this