### PR TITLE
ui: fix checkin activity view

### DIFF
--- a/functions/src/migrations/backfillCheckinViewerIds.ts
+++ b/functions/src/migrations/backfillCheckinViewerIds.ts
@@ -1,0 +1,48 @@
+// ran with:
+// ./node_modules/.bin/esbuild src/migrations/backfillCheckinViewerIds.ts --bundle --minify --sourcemap --platform=node --target=node16 --outfile=build/backfill.js && node build/backfill.js ./service-account-private-key.json
+
+import * as admin from "firebase-admin"
+
+const config = {
+  credential: admin.credential.cert(process.argv[2]),
+}
+
+admin.initializeApp(config)
+
+const db = admin.firestore()
+
+async function main() {
+  const queryResult = await db.collection("places").orderBy("createdAt").get()
+  queryResult.forEach(async (placeDoc) => {
+    // eslint-disable-next-line no-console
+    console.log("place_id", placeDoc.id)
+    // eslint-disable-next-line no-console
+    console.log("place", placeDoc.data().name)
+    const checkins = await db.collection(`places/${placeDoc.id}/checkins`).get()
+    checkins.forEach(async (checkinDoc) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const placeViewerIds = placeDoc.data().viewerIds
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const viewerIds = checkinDoc.data().viewerIds
+      if (viewerIds == null) {
+        // eslint-disable-next-line no-console
+        console.log("updating...", checkinDoc.ref.path)
+        const update = {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          viewerIds: placeViewerIds ?? [],
+        }
+        await db.doc(checkinDoc.ref.path).update(update)
+        // eslint-disable-next-line no-console
+        console.log("updated!", checkinDoc.ref.path)
+      } else {
+        // eslint-disable-next-line no-console
+        console.log("skipping, has viewerIds already", checkinDoc.ref.path)
+      }
+    })
+  })
+}
+
+main().catch((e) => {
+  // eslint-disable-next-line no-console
+  console.error(e)
+})

--- a/ui/src/api-schemas.ts
+++ b/ui/src/api-schemas.ts
@@ -53,6 +53,7 @@ export const PlaceCheckInSchema = BaseSchema.extend({
   checkedInAt: z.nullable(TimestampSchema),
   comment: z.string(),
   ratingsMenuItemIds: z.array(z.string()).default([]),
+  viewerIds: z.array(z.string()),
   ratings: z.array(
     z.object({
       menuItemId: z.string(),

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -81,12 +81,14 @@ export const checkin = {
     userId,
     comment,
     reviews,
+    viewerIds,
   }: {
     placeId: string
     date: Date | null
     userId: string
     comment: string
     reviews: { menuItemId: string; rating: -1 | 1; comment: string }[]
+    viewerIds: string[]
   }) {
     const checkin: Omit<PlaceCheckIn, "id"> = {
       createdAt: Timestamp.now(),
@@ -95,6 +97,7 @@ export const checkin = {
       lastModifiedAt: null,
       lastModifiedById: null,
       comment,
+      viewerIds,
       ratings: reviews,
       ratingsMenuItemIds: reviews.map((x) => x.menuItemId),
     }
@@ -121,7 +124,7 @@ export const checkin = {
   }) {
     const checkin: Omit<
       PlaceCheckIn,
-      "id" | "createdById" | "createdAt" | "deleted"
+      "id" | "createdById" | "createdAt" | "deleted" | "viewerIds"
     > = {
       checkedInAt: date != null ? Timestamp.fromDate(date) : null,
       lastModifiedAt: Timestamp.now(),

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -6,6 +6,7 @@ import {
 } from "firebase/auth"
 import {
   collection,
+  collectionGroup,
   doc,
   DocumentData,
   DocumentReference,
@@ -229,12 +230,9 @@ export function useActivities({
       )
     } else if (filter === "checkins") {
       return query(
-        collection(db, "activities"),
+        collectionGroup(db, "checkins"),
         where("viewerIds", "array-contains", userId),
-        where("deleted", "==", false),
-        where("document", "==", "checkin"),
-        where("type", "==", "create"),
-        orderBy("createdAt", "desc"),
+        orderBy("checkedInAt", "desc"),
       )
     } else {
       assertNever(filter)

--- a/ui/src/pages/CheckInCreateView/CheckInCreateView.page.tsx
+++ b/ui/src/pages/CheckInCreateView/CheckInCreateView.page.tsx
@@ -298,6 +298,7 @@ export function CheckInCreateView() {
                 date: isDateEnabled ? parseISO(date) : null,
                 placeId: place.id,
                 comment,
+                viewerIds: place.viewerIds,
                 reviews: menuItemRatings,
               })
               .then((checkInId) => {


### PR DESCRIPTION
we were showing when a checkin was created, not when the checkin occured

now we're using a collectionGroup query against the checkins themselves which simplifies things, sort of, but requires us to keep track of another set of viewerIds for ACL purposes.