### PR TITLE
ui: fix security rules for collectionGroup query

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -25,7 +25,7 @@ service cloud.firestore {
             && (data.lastModifiedAt == null || data.lastModifiedAt is timestamp)
     }
     match /places/{place} {
-    function placeData() {
+      function placeData() {
         return get(/databases/$(database)/documents/places/$(place))
       }
       function canViewPlace(request, resource) {
@@ -121,6 +121,11 @@ service cloud.firestore {
         allow delete: if canViewPlace(request, placeData())
           && resource.data.createdById == request.auth.uid
       }
+    }
+
+    match /{path=**}/checkins/{checkin} {
+      allow read: if request.auth.uid in resource.data.viewerIds
+      allow create, update, delete: if false
     }
     
     match /activities/{activity} {

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -61,6 +61,8 @@ function useQuery<T extends z.ZodType>(
         },
         (error) => {
           // eslint-disable-next-line no-console
+          console.error("error with query")
+          // eslint-disable-next-line no-console
           console.error(error)
           setState("error")
         },
@@ -79,6 +81,8 @@ function useQuery<T extends z.ZodType>(
           setState(out)
         },
         (error) => {
+          // eslint-disable-next-line no-console
+          console.error("error with query")
           // eslint-disable-next-line no-console
           console.error(error)
           setState("error")


### PR DESCRIPTION
turns out we need more ACLs for collectionGrups, they use a different syntax vs normal collections