### PR TITLE
ui: remove createdAt time from checkin list view

### DIFF
--- a/ui/src/pages/ActivityView.page.tsx
+++ b/ui/src/pages/ActivityView.page.tsx
@@ -131,7 +131,6 @@ function CheckinCreated({ checkin }: { checkin: PlaceCheckInJoined }) {
           </Text>
         }{" "}
       </div>
-      <Box>{format(checkin.createdAt.toDate(), "h:mmaaa")}</Box>
     </HStack>
   )
 }

--- a/ui/src/pages/ActivityView.page.tsx
+++ b/ui/src/pages/ActivityView.page.tsx
@@ -14,7 +14,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react"
-import { format, formatISO } from "date-fns"
+import { formatISO } from "date-fns"
 import { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 


### PR DESCRIPTION
this is the time when the checkin itself was created, not the date of the checkin